### PR TITLE
Implement typing indicator and message history

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
         </div>
         <div id="Chat" style="display:none;">
         </div>
+        <div id="typingIndicator" style="display:none;" class="typing-indicator"></div>
 
         <div id="MessageSection" style="display:none;">
             <label id="MessageLabel">Message</label>

--- a/index.js
+++ b/index.js
@@ -18,9 +18,11 @@ httpServer.listen(PORT, () => {
 });
 
 const onlineUsers = new Map();
-const rooms = new Map(); 
+const rooms = new Map();
 const usernames = new Map();
 const GLOBAL_CHAT = 'global';
+const messageHistory = new Map();
+const HISTORY_LIMIT = 100;
 
 io.on('connection', function (socket) {
     socket.on("checkUsername", function (room, username, callback) {
@@ -71,6 +73,7 @@ io.on('connection', function (socket) {
         });
 
         socket.emit("join", normalizedRoom === GLOBAL_CHAT ? '' : normalizedRoom);
+        socket.emit("history", messageHistory.get(normalizedRoom) || []);
     });
 
 
@@ -101,6 +104,7 @@ io.on('connection', function (socket) {
 
             if (onlineUsers.get(room).size === 0) {
                 onlineUsers.delete(room);
+                messageHistory.delete(room);
             }
         }
 
@@ -118,37 +122,57 @@ io.on('connection', function (socket) {
         const room = rooms.get(socket.id);
         const username = usernames.get(socket.id);
         if (!room || !username || !message?.text?.trim()) return;
-        io.in(room).emit("recieve", {
+        const msg = {
             text: message.text,
             username: username,
             time: message.time,
             type: 'text'
-        });
+        };
+        io.in(room).emit("recieve", msg);
+        storeMessage(room, msg);
     });
 
     socket.on("sendImage", function (message) {
         const room = rooms.get(socket.id);
         const username = usernames.get(socket.id);
         if (!room || !username || !message?.image) return;
-        io.in(room).emit("recieve", {
+        const msg = {
             image: message.image,
             username: username,
             time: message.time,
             type: 'image'
-        });
+        };
+        io.in(room).emit("recieve", msg);
+        storeMessage(room, msg);
     });
 
     socket.on("sendImageText", function (message) {
         const room = rooms.get(socket.id);
         const username = usernames.get(socket.id);
         if (!room || !username || (!message?.text && !message?.image)) return;
-        io.in(room).emit("recieve", {
+        const msg = {
             text: message.text,
             image: message.image,
             username: username,
             time: message.time,
             type: 'image+text'
-        });
+        };
+        io.in(room).emit("recieve", msg);
+        storeMessage(room, msg);
+    });
+
+    socket.on('typing', function () {
+        const room = rooms.get(socket.id);
+        const username = usernames.get(socket.id);
+        if (!room || !username) return;
+        socket.to(room).emit('typing', username);
+    });
+
+    socket.on('stopTyping', function () {
+        const room = rooms.get(socket.id);
+        const username = usernames.get(socket.id);
+        if (!room || !username) return;
+        socket.to(room).emit('stopTyping', username);
     });
 
     socket.on('disconnect', function () {
@@ -165,4 +189,15 @@ io.on('connection', function (socket) {
 function getCurrentTime() {
     const now = new Date();
     return now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function storeMessage(room, msg) {
+    if (!messageHistory.has(room)) {
+        messageHistory.set(room, []);
+    }
+    const history = messageHistory.get(room);
+    history.push(msg);
+    if (history.length > HISTORY_LIMIT) {
+        history.shift();
+    }
 }

--- a/script.js
+++ b/script.js
@@ -2,6 +2,9 @@ let socket, usernameInput, chatIDInput, messageInput, chatRoom, dingSound;
 let messages = [];
 let delay = true;
 let selectedImageFile = null;
+let typingTimeout = null;
+let isTyping = false;
+const typingUsers = new Set();
 
 function onload() {
     socket = io();
@@ -32,6 +35,7 @@ function setupEventListeners() {
             Send();
         }
     });
+    messageInput.addEventListener('input', handleTyping);
 
     socket.on('updateOnlineUsers', data => {
         const element = document.getElementById('online-count');
@@ -45,6 +49,21 @@ function setupEventListeners() {
         ['Chat', 'MessageSection', 'ExitButton'].forEach(id => {
             document.getElementById(id).style.display = 'block';
         });
+    });
+
+    socket.on('history', history => {
+        messages = history;
+        updateMessages();
+    });
+
+    socket.on('typing', username => {
+        typingUsers.add(username);
+        renderTypingIndicator();
+    });
+
+    socket.on('stopTyping', username => {
+        typingUsers.delete(username);
+        renderTypingIndicator();
     });
 
     socket.on('recieve', message => {
@@ -250,6 +269,11 @@ function Send() {
         socket.emit('send', message);
         resetMessageInput();
     }
+
+    if (isTyping) {
+        socket.emit('stopTyping');
+        isTyping = false;
+    }
 }
 
 function resetMessageInput() {
@@ -309,6 +333,36 @@ function openImageMenu() {
     document.getElementById('ImageInput').click();
 }
 
+function handleTyping() {
+    if (!isTyping && messageInput.value.trim()) {
+        socket.emit('typing');
+        isTyping = true;
+    }
+
+    clearTimeout(typingTimeout);
+    if (messageInput.value.trim()) {
+        typingTimeout = setTimeout(() => {
+            socket.emit('stopTyping');
+            isTyping = false;
+        }, 1000);
+    } else if (isTyping) {
+        socket.emit('stopTyping');
+        isTyping = false;
+    }
+}
+
+function renderTypingIndicator() {
+    const indicator = document.getElementById('typingIndicator');
+    if (typingUsers.size === 0) {
+        indicator.style.display = 'none';
+        indicator.textContent = '';
+        return;
+    }
+
+    indicator.style.display = 'block';
+    indicator.textContent = `${Array.from(typingUsers).join(', ')} is typing...`;
+}
+
 function displayErrorMessages(field, message) {
     document.getElementById(field === 'username' ? 'usernameError' : 'roomIDError').textContent = message;
 }
@@ -338,5 +392,9 @@ function exitChat() {
     document.getElementById("AccessPort").style.display = 'block';
     document.getElementById("ExitButton").style.display = 'none';
 
+    if (isTyping) {
+        socket.emit('stopTyping');
+        isTyping = false;
+    }
     socket.emit("leave", currentRoomID, username);
 }

--- a/style.css
+++ b/style.css
@@ -302,3 +302,9 @@ input[type="text"]:focus, input[type="tel"]:focus, input#ComposedMessage:focus {
 #online-users-counter {
   color: #00bf40;
 }
+
+.typing-indicator {
+  color: #cfcfcf;
+  font-style: italic;
+  margin-bottom: 5px;
+}


### PR DESCRIPTION
## Summary
- keep last 100 messages per room on the server and send history when users join
- show typing status for each user
- added typing indicator element and styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686ea0ae18f083319c9d688e01fc5227