### PR TITLE
Add deletion, selection and reaction features

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,6 +151,20 @@ io.on('connection', function (socket) {
         });
     });
 
+    socket.on('deleteMessage', function (data) {
+        const room = rooms.get(socket.id);
+        const username = usernames.get(socket.id);
+        if (!room || !username) return;
+        io.in(room).emit('deleteMessage', { id: data.id });
+    });
+
+    socket.on('addReaction', function (data) {
+        const room = rooms.get(socket.id);
+        const username = usernames.get(socket.id);
+        if (!room || !username) return;
+        io.in(room).emit('addReaction', { id: data.id, emoji: data.emoji, username: username });
+    });
+
     socket.on('disconnect', function () {
         const room = rooms.get(socket.id);
         const username = usernames.get(socket.id);

--- a/style.css
+++ b/style.css
@@ -129,6 +129,28 @@ h2#RoomID {
   border-radius: 5px;
   word-wrap: break-word;
 }
+.message-block.selected {
+  background-color: rgba(250, 58, 108, 0.2);
+}
+
+.action-menu {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.action-menu button {
+  background: none;
+  border: none;
+  color: #fa3a6c;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.reaction-container span {
+  margin-right: 4px;
+  color: #fa3a6c;
+}
 
 .sender-message {
   background-color: #fa3a6c;


### PR DESCRIPTION
## Summary
- allow selecting messages on hold and show menu
- add delete and reaction actions
- highlight selected blocks via CSS
- include event handlers for new socket events

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686ea454d5448331ada09f18a3adc3ef