### PR TITLE
Add landing page and modernize UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,17 +9,25 @@
     <meta property="og:url" content="https://echomsg.onrender.com" />
     <title>Echo Msg: Connect and Chat Instantly</title>
     <link rel="stylesheet" type="text/css" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
     <script src="socket.io/socket.io.js"></script>
     <script src="script.js" defer></script>
 </head>
 <body onload="onload()">
     <div id="Main">
         <audio id="Ding" src="Ding.mp3"></audio>
-        <div id="online-users-counter">
-            Online Users: <span id="online-count">0</span>
-        </div>
-        <h1 id="Title">Echo Msg</h1>
-        <div id="AccessPort">
+
+        <section id="landing">
+            <h1 class="landing-title">Echo Msg</h1>
+            <p class="tagline">Connect and chat instantly with anyone.</p>
+            <input id="StartButton" class="Button" type="button" value="Start Chatting" onclick="startChat()">
+        </section>
+
+        <div id="AccessPort" style="display:none;">
+            <div id="online-users-counter">
+                Online Users: <span id="online-count">0</span>
+            </div>
+            <h1 id="Title">Echo Msg</h1>
             <label id="NameLabel">Username</label>
             <input id="NameInput" type="text" placeholder="Enter your username" required>
             <div id="usernameError" class="error-message"></div>

--- a/script.js
+++ b/script.js
@@ -14,11 +14,21 @@ function onload() {
 }
 
 function setInitialDisplay() {
-    ['Chat', 'MessageSection', 'ExitButton'].forEach(id => {
-        document.getElementById(id).style.display = 'none';
+    ['Chat', 'MessageSection', 'ExitButton', 'AccessPort'].forEach(id => {
+        const element = document.getElementById(id);
+        if (element) element.style.display = 'none';
     });
+    const landing = document.getElementById('landing');
+    if (landing) landing.style.display = 'block';
     document.getElementById('imagePreview').style.display = 'none';
     document.getElementById('imageName').textContent = '';
+}
+
+function startChat() {
+    const landing = document.getElementById('landing');
+    const accessPort = document.getElementById('AccessPort');
+    if (landing) landing.style.display = 'none';
+    if (accessPort) accessPort.style.display = 'block';
 }
 
 function setupEventListeners() {

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
 }
 
 body {
-  font-family: 'Arial', sans-serif;
+  font-family: 'Poppins', sans-serif;
   background-color: #121212;
   color: #e0e0e0;
   line-height: 1.6;
@@ -24,6 +24,27 @@ body {
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
   max-width: 500px;
   width: 100%;
+}
+
+#landing {
+  text-align: center;
+  padding: 60px 20px;
+}
+
+#landing .landing-title {
+  color: #fa3a6c;
+  font-size: 2.5rem;
+  margin-bottom: 10px;
+}
+
+#landing .tagline {
+  color: #cfcfcf;
+  margin-bottom: 30px;
+}
+
+#landing .Button {
+  width: auto;
+  padding: 10px 30px;
 }
 
 h1#Title {
@@ -65,7 +86,7 @@ input[type="text"], input[type="tel"] {
   margin: 5px 0 10px;
 }
 
-input.Button {
+.Button {
   padding: 10px 20px;
   background-color: #fa3a6c;
   color: #e0e0e0;
@@ -78,7 +99,7 @@ input.Button {
   margin-bottom: 10px;
 }
 
-input.Button:hover {
+.Button:hover {
   background-color: #d02858;
 }
 


### PR DESCRIPTION
## Summary
- Add new landing section with startup-style hero and call to action
- Import Poppins font and centralize button styles for a clean look
- Provide startChat helper to show login form after landing screen

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689836582c388331b20a81ba02b997cf